### PR TITLE
Minor compatibility improvements

### DIFF
--- a/CompareGeneProfiles/cgp_compareGeneProfiles_main.py
+++ b/CompareGeneProfiles/cgp_compareGeneProfiles_main.py
@@ -39,7 +39,6 @@ BACTERIAL_CODE = 11
 
 import sys, os, re, string, copy
 from Bio.Seq import Seq
-from Bio.Alphabet import generic_dna, generic_protein
 from time import strftime
 from time import gmtime
 import datetime

--- a/CompareGeneProfiles/cgp_fastaSequence.py
+++ b/CompareGeneProfiles/cgp_fastaSequence.py
@@ -81,7 +81,6 @@
 
 import re, string
 from Bio.Seq import Seq
-from Bio.Alphabet import generic_dna, generic_protein
 import cgp_annotation as annotation
 from Bio import SeqIO  
 import os

--- a/CompareGeneProfiles/cgp_genomeSequence.py
+++ b/CompareGeneProfiles/cgp_genomeSequence.py
@@ -55,7 +55,6 @@
 
 import string
 from Bio.Seq import Seq
-from Bio.Alphabet import generic_dna, generic_protein
 import cgp_fastaSequence as fastaSequence
 import cgp_annotation as annotation
 import re, os, copy

--- a/SequenceAnnotation/phate_blast.py
+++ b/SequenceAnnotation/phate_blast.py
@@ -460,7 +460,7 @@ class multiBlast(object):
                     blastQuery = child.text
 
             # Find hits and extract hit data
-            for hit in root.getiterator('Hit'):  
+            for hit in root.iter('Hit'):  
                 # reset
                 speciesList = []; doPrint = False
                 querySeq = ""; subjectSeq = ""; hitDefline = ""


### PR DESCRIPTION
This PR has three minor compatibility improvements because of deprecated code:

1. `getiterator()` is deprecated from `xml.etree.ElementTree`. For more information, please see the [description at lxml](https://lxml.de/api/lxml.etree._Element-class.html#getiterator). This has now been replaced by the `.iter()` function.

2. Bio.Alphabet has been [completely deprecated](https://github.com/biopython/biopython/issues/2046). For these three files, generic_dna and generic_protein were imported from Bio.Alphabet and never used. The import caused things to break.  Removing the import statement removes this issue.